### PR TITLE
Fix for Issue #7 (xmlReader moving beyond EndElement)

### DIFF
--- a/src/Core/LogEntryParser.cs
+++ b/src/Core/LogEntryParser.cs
@@ -199,7 +199,16 @@ namespace LogViewer
 						{
 							throw new Exception("EVENTCHILDREN1: Expected a known name but was: " + xmlreader.Name);
 						}
-						break;
+
+                        //Fix for issue #7
+                        if (xmlreader.NodeType == XmlNodeType.EndElement)
+                        {
+                            if (Object.ReferenceEquals(xmlreader.LocalName, names.@event))
+                            {
+                                return;
+                            }
+                        }
+                        break;
 					case XmlNodeType.EndElement:
 						if (Object.ReferenceEquals(xmlreader.LocalName, names.@event))
 						{

--- a/src/Tests/Log4JTests.cs
+++ b/src/Tests/Log4JTests.cs
@@ -210,5 +210,57 @@ level=""ERROR"" thread=""7"">
 
             }
         }
+
+
+        /// <summary>
+        /// Used to reproduce issue #7
+        /// Error when reading logfile with throwable as last Event child.
+        /// In order to reproduce, the sample data must contain more than one log line.
+        /// </summary>
+        [Fact]
+        public void ParseWithThrowableAsLastChildElement()
+        {
+            using (var s = new MemoryStream())
+            using (var w = new StreamWriter(s))
+            {
+
+                var lines =
+                  @"<log4j:event 
+logger=""IntegrationTests.LogTests"" 
+timestamp=""1300909721869"" 
+level=""ERROR"" thread=""7"">
+<log4j:message>msg</log4j:message>
+<log4j:properties>
+	<log4j:data name=""log4net:UserName"" value=""AWESOMEMACHINE\Administrator"" />
+	<log4j:data name=""log4jmachinename"" value=""AWESOMEMACHINE"" />
+	<log4j:data name=""log4japp"" value=""IsolatedAppDomainHost: IntegrationTests"" />
+	<log4j:data name=""log4net:HostName"" value=""AWESOMEMACHINE"" />
+</log4j:properties>
+<log4j:locationInfo 
+	class=""IntegrationTests.LogTests"" method=""TestLog"" 
+	file=""C:\projects\LogViewer\IntegrationTests\LogTests.cs"" 
+	line=""27"" />
+<log4j:throwable>System.Exception: test</log4j:throwable></log4j:event>
+<log4j:event logger=""HomeController"" timestamp=""1361528145331"" level=""ERROR"" thread=""91"">
+<log4j:message>error</log4j:message>
+<log4j:properties>
+    <log4j:data name=""log4net:UserName"" value=""SOMEDOMAIN\someuser"" />
+    <log4j:data name=""log4net:Identity"" value=""44045"" />
+    <log4j:data name=""log4jmachinename"" value=""somemachine"" />
+    <log4j:data name=""log4japp"" value=""/LM/W3SVC/1"" />
+    <log4j:data name=""log4net:HostName"" value=""SOMEHOST"" />
+</log4j:properties>
+<log4j:locationInfo class=""MyController"" method=""Log"" file=""C:\project\MyController.cs"" line=""99"" />
+</log4j:event>";
+
+                w.Write(lines);
+                w.Flush();
+                s.Position = 0;
+
+                var entry = new LogEntryParser().Parse(s).ToList();
+                Assert.Equal(2, entry.Count);
+
+            }
+        }
     }
 }


### PR DESCRIPTION
When a log line entry ends with an entity that is read using xmlReader.ReadInnerXml, the reader is moved to the next element which is an EndElement. 
If then the next xmlReader.Read is performed, the reader skips the EndElement which is expected in code and throws an error due to an unexpected element.
This seems to only happen if there is no whitespace or other element before the next log4j:event element.

I've added a new test ParseWithThrowableAsLastChildElement to reproduce the error.
The fix is included in private void EventChildren()